### PR TITLE
fix(diffusion_gemma): init preempt-rebuild runtime fields in init_multi_block

### DIFF
--- a/diffulex/strategy/diffusion_gemma/engine/request.py
+++ b/diffulex/strategy/diffusion_gemma/engine/request.py
@@ -26,6 +26,8 @@ class DiffusionGemmaReq(DllmReq):
         self.is_multi_block = True
         self.status_history = [self.status]
         self.completion_reason = None
+        self._resume_prefill_until = 0
+        self._terminal_context_block_id: int | None = None
 
         self.block_size = config.block_size
         self.buffer_size = config.buffer_size


### PR DESCRIPTION
## Summary

- Initialize `_resume_prefill_until` and `_terminal_context_block_id` in `DiffusionGemmaReq.init_multi_block()`.
- `DiffusionGemmaReq` overrides `init_multi_block` without calling `super()`, so after the preempt-rebuild changes in base `DllmReq` (`609b593`), these runtime fields were never set.
- This caused `AttributeError` on the first `step()` → `lazy_activate()` when running the DiffusionGemma GSM8K benchmark.

Fixes #45 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request initialization to better support ongoing diffusion workflows and context handling, helping reduce unexpected interruptions during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->